### PR TITLE
Blackhole exporter

### DIFF
--- a/docs/configuration/exporters/blackhole.md
+++ b/docs/configuration/exporters/blackhole.md
@@ -1,0 +1,19 @@
+---
+sidebar_position: 5
+---
+
+# Blackhole Exporter
+
+| Telemetry Type | Support |
+|----------------|---------|
+| Traces         | Alpha   |
+| Metric         | Alpha   |
+| Logs           | Alpha   |
+
+
+The blackhole exporter will drop all telemetry exported immediately. It can be useful when debugging
+and you're using the `--debug-log` option to log telemetry. It can also be useful if you are using
+an exporter that doesn't support a given telemetry type, but you'd still like to listen and receive
+the remaining telemetry types.
+
+The blackhole exporter can be used by specifying `--exporter blackhole`.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",
-    "start": "docusaurus start",
+    "start": "docusaurus start --no-open",
     "build": "docusaurus build",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",


### PR DESCRIPTION
Include the blackhole exporter in the docs.

Switch the default to not pop open a browser window when running locally. This doesn't work on Mac and can be annoying to keep opening new windows.

Completes: STR-3501