### PR TITLE
Blog/doc updates

### DIFF
--- a/blog/2025-08-05/index.md
+++ b/blog/2025-08-05/index.md
@@ -115,7 +115,7 @@ Rotel’s early roadmap came from our own experience and the feedback of users. 
 
 Rotel started with full OpenTelemetry Protocol (OTLP) compatibility and has grown to support a handful of exporter integrations. We want to expand support for additional use cases, both on the receiver and exporter sides. Object storage is crucial for building large-scale telemetry systems, so we plan to add an exporter for it along with support for popular columnar storage formats. Work is already in progress on an Apache Parquet writer.
 
-Rotel only receives OTLP data at the moment, but we want to expand this to include file log tailing and remote scraping of endpoints like Prometheus. We have recently added a Kafka exporter and Kafka receiver, allowing for stream processing of OpenTelemetry data.
+Rotel only receives OTLP data at the moment, but we want to expand this to include file log tailing and remote scraping of endpoints like Prometheus. We have recently added a Kafka exporter and Kafka receiver, allowing users to build end-to-end stream processing of OpenTelemetry data with Rotel.
 
 ### Expanding Processor and OTTL support
 
@@ -125,7 +125,7 @@ We also intend to investigate OTTL support. While anything written in a domain s
 
 ### Durable Pipelines
 
-You can hope for the best, but sometimes you have to plan for the worst, and telemetry pipelines are no exception. Rotel should provide the option to build durable pipelines with options like guaranteed at-least-once delivery, for receivers and exporters that support it. Rotel should allow telemetry to be spooled to disk or S3 when export destinations are offline for extended durations. We want to support durability with little to no overhead and in a way that is simple to configure.
+You can hope for the best, but sometimes you have to plan for the worst, and telemetry pipelines are no exception. Rotel should provide the option to build durable pipelines with options like guaranteed at-least-once delivery, for receivers and exporters that support it. Rotel should allow telemetry to be spooled to disk or S3 when export destinations are offline for extended durations. We want to support durability with little to no overhead and in a way that is simple to configure. Check out the [RFC](https://github.com/streamfold/rotel/discussions/186) to join in the discussion on adding delivery acknowledgement to Rotel.
 
 ### OpenTelemetry Arrow
 

--- a/blog/2025-08-05/index.md
+++ b/blog/2025-08-05/index.md
@@ -4,7 +4,6 @@ title: "Rotel: Fast and Efficient OpenTelemetry Collection in Rust"
 authors: [rjenkins, mheffner]
 tags: [announcements]
 image: ./red_pepper.png
-showLastUpdateTime: true
 ---
 
 Observability shouldn't be a resource hog, that’s why at the end of last year, we started an ambitious new project – Rotel. We’ve been excited to see the rise of OpenTelemetry as a vendor neutral standard for telemetry and it's inspired us to apply our systems experience to develop a high-performance, resource efficient data plane for collecting OpenTelemetry data.

--- a/blog/2025-08-05/index.md
+++ b/blog/2025-08-05/index.md
@@ -55,7 +55,7 @@ telemetrygen traces --otlp-insecure --duration 5s
 
 From the Rotel container you’ll then see log messages indicating it has received trace spans.
 
-See the full [Getting Started](https://rotel.dev/docs/setup/getting-started) guide for more information.
+See the full [Getting Started](/docs/setup/getting-started) guide for more information.
 
 ## Advanced Capabilities
 

--- a/blog/2025-08-05/index.md
+++ b/blog/2025-08-05/index.md
@@ -4,9 +4,10 @@ title: "Rotel: Fast and Efficient OpenTelemetry Collection in Rust"
 authors: [rjenkins, mheffner]
 tags: [announcements]
 image: ./red_pepper.png
+showLastUpdateTime: true
 ---
 
-Observability shouldn't be a resource hog, that’s why at the end of last year, we started an ambitious new project – Rotel. We’ve been excited to see the rise of OpenTelemetry as a vendor neutral standard for telemetry and it's inspired us to apply our systems experience to develop a high-performance, resource efficient data plane for collecting OpenTelemetry data. 
+Observability shouldn't be a resource hog, that’s why at the end of last year, we started an ambitious new project – Rotel. We’ve been excited to see the rise of OpenTelemetry as a vendor neutral standard for telemetry and it's inspired us to apply our systems experience to develop a high-performance, resource efficient data plane for collecting OpenTelemetry data.
 
 Rotel is a new open-source alternative for collecting OpenTelemetry data and is engineered to be an efficient, high-performance solution for receiving, processing, and exporting OpenTelemetry data. Rotel runs as a standalone process and consumes telemetry from external processes or other collection agents. It consumes **75% less memory and 50% less CPU** in benchmarks, so it is particularly well-suited for environments where resource optimization is paramount.
 
@@ -30,11 +31,11 @@ Beyond the practical implications, these questions also felt like an **exciting 
 
 ### Key Capabilities
 
-* **Comprehensive OTLP Support:** Rotel acts as an OTLP receiver and exporter, supporting gRPC, HTTP/Protobuf, and HTTP/JSON.  
-* **Flexible Exporter Options:** Beyond standard OTLP export, Rotel includes exporters for ClickHouse, Datadog, Kafka, and AWS X-Ray.  
-* **Resource Efficiency:** Up to 75% less memory utilization and 50% less cpu usage on [OpenTelemetry collector benchmarks](https://streamfold.github.io/rotel-otel-loadtests/benchmarks/).  
-* **Serverless Extension**: Easily deploy Rotel on AWS Lambda as an extension with very fast cold-start times.  
-* **Robust Data Delivery:** Built-in batching, retry mechanisms, and configurable timeouts ensure reliable data delivery  
+* **Comprehensive OTLP Support:** Rotel acts as an OTLP receiver and exporter, supporting gRPC, HTTP/Protobuf, and HTTP/JSON.
+* **Flexible Exporter Options:** Beyond standard OTLP export, Rotel includes exporters for ClickHouse, Datadog, Kafka, AWS EMF, and AWS X-Ray.
+* **Resource Efficiency:** Up to 75% less memory utilization and 50% less cpu usage on [OpenTelemetry collector benchmarks](https://streamfold.github.io/rotel-otel-loadtests/benchmarks/).
+* **Serverless Extension**: Easily deploy Rotel on AWS Lambda as an extension with very fast cold-start times.
+* **Robust Data Delivery:** Built-in batching, retry mechanisms, and configurable timeouts ensure reliable data delivery
 * **Runtime Integrations:** Easily bundle Rotel with popular runtimes. We provide simple to use integrations for Python ([streamfold/pyrotel](https://github.com/streamfold/pyrotel)) and Node.js ([streamfold/rotel-nodejs](https://github.com/streamfold/rotel-nodejs)).
 
 ## Getting Started
@@ -53,7 +54,7 @@ go install github.com/open-telemetry/opentelemetry-collector-contrib/cmd/telemet
 telemetrygen traces --otlp-insecure --duration 5s
 ```
 
-From the Rotel container you’ll then see log messages indicating it has received trace spans. 
+From the Rotel container you’ll then see log messages indicating it has received trace spans.
 
 See the full [Getting Started](https://rotel.dev/docs/setup/getting-started) guide for more information.
 
@@ -115,7 +116,7 @@ Rotel’s early roadmap came from our own experience and the feedback of users. 
 
 Rotel started with full OpenTelemetry Protocol (OTLP) compatibility and has grown to support a handful of exporter integrations. We want to expand support for additional use cases, both on the receiver and exporter sides. Object storage is crucial for building large-scale telemetry systems, so we plan to add an exporter for it along with support for popular columnar storage formats. Work is already in progress on an Apache Parquet writer.
 
-Rotel only receives OTLP data at the moment, but we want to expand this to include file log tailing and remote scraping of endpoints like Prometheus. We have recently added a Kafka exporter and plan to follow this with support for a Kafka receiver soon.  
+Rotel only receives OTLP data at the moment, but we want to expand this to include file log tailing and remote scraping of endpoints like Prometheus. We have recently added a Kafka exporter and Kafka receiver, allowing for stream processing of OpenTelemetry data.
 
 ### Expanding Processor and OTTL support
 

--- a/docs/setup/getting-started.md
+++ b/docs/setup/getting-started.md
@@ -1,10 +1,8 @@
 # Getting started
 
-To quickly get started with Rotel you can leverage the pre-built Docker images.
+To quickly get started with Rotel you can leverage the pre-built Docker images. Alternatively, you can download a binary from the [releases](https://github.com/streamfold/rotel/releases) page.
 
 ## Running Rotel
-
-We use the prebuilt docker image for this example, but you can also download a binary from the [releases](https://github.com/streamfold/rotel/releases) page.
 
 Execute Rotel with the following arguments:
 

--- a/docs/setup/getting-started.md
+++ b/docs/setup/getting-started.md
@@ -2,23 +2,32 @@
 
 To quickly get started with Rotel you can leverage the pre-built Docker images.
 
-1. **Running Rotel**
-    - We use the prebuilt docker image for this example, but you can also download a binary from the
-      [releases](https://github.com/streamfold/rotel/releases) page.
-    - Execute Rotel with the following arguments. To debug metrics or logs, add
-      an additional `--debug-log metrics|logs`.
-   ```bash
-   docker run -ti -p 4317-4318:4317-4318 streamfold/rotel --debug-log traces --exporter blackhole
-   ```
-    - Rotel is now listening on localhost:4317 (gRPC) and localhost:4318 (HTTP).
+## Running Rotel
 
-2. **Verify**
-    - Send OTLP traces to Rotel and verify that it is receiving data:
-   ```bash
-   go install github.com/open-telemetry/opentelemetry-collector-contrib/cmd/telemetrygen@latest
-   
-   telemetrygen traces --otlp-insecure --duration 5s
-   ```
-    - Check the output from Rotel and you should see several "Received traces" log lines.
+We use the prebuilt docker image for this example, but you can also download a binary from the [releases](https://github.com/streamfold/rotel/releases) page.
 
-Next step, connect an exporter and test for end-to-end delivery.
+Execute Rotel with the following arguments:
+
+```bash
+docker run -ti -p 4317-4318:4317-4318 streamfold/rotel --debug-log traces --exporter blackhole
+```
+
+Rotel is now listening on `localhost:4317` (gRPC) and `localhost:4318` (HTTP). To debug metrics or logs,
+add an additional `--debug-log metrics|logs`.
+
+## Verify
+
+We'll use the [telemetrygen](https://pkg.go.dev/github.com/open-telemetry/opentelemetry-collector-contrib/cmd/telemetrygen) project to verify Rotel is working. Send OTLP traces to Rotel and verify
+that it is receiving data:
+
+```bash
+go install github.com/open-telemetry/opentelemetry-collector-contrib/cmd/telemetrygen@latest
+
+telemetrygen traces --otlp-insecure --duration 5s
+```
+
+Check the output from Rotel and you should see several "Received traces" log lines.
+
+## Next
+
+Check out the full configuration documentation for connecting an exporter and testing end-to-end delivery.

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -107,6 +107,7 @@ const config: Config = {
           onInlineTags: 'warn',
           onInlineAuthors: 'warn',
           onUntruncatedBlogPosts: 'warn',
+          showLastUpdateTime: true,
         },
         theme: {
           customCss: './src/css/custom.css',

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -44,7 +44,7 @@ function HomepageHeader(): JSX.Element {
         <div className={styles.buttons}>
           <Link
             className="button button--secondary button--lg"
-            to="/docs/"> {/* Updated to docs root */}
+            to="/docs/setup/getting-started"> {/* Updated to docs root */}
             Get Started - 5min ⏱️
           </Link>
           <Link
@@ -284,7 +284,7 @@ def redact_emails(body: AnyValue) -> AnyValue:
                           <h3>Receivers & Processing</h3>
                           <ul className={styles.featureList}>
                               <li>OTLP/gRPC, OTLP/HTTP, OTLP/HTTP-JSON receivers</li>
-                              <li>Automatic batching for optimal delivery</li>
+                              <li>Kafka receiver for metric, logs, and traces</li>
                               <li>Python processor support</li>
                               <li>Out-of-the-box processors or write your own</li>
                               <li>Adaptive flushing that minimizes lambda overhead</li>
@@ -296,11 +296,11 @@ def redact_emails(body: AnyValue) -> AnyValue:
                           <div className={styles.featureIcon}>📤</div>
                           <h3>Exporters & Destinations</h3>
                           <ul className={styles.featureList}>
-                              <li>OTLP (gRPC/HTTP) exporters</li>
-                              <li>Clickhouse exporter</li>
-                              <li>Kafka exporter</li>
-                              <li>Datadog & AWS X-Ray trace exporters</li>
-                              <li>Debug & logging exporters</li>
+                              <li>OTLP (gRPC/HTTP)</li>
+                              <li>Clickhouse</li>
+                              <li>Kafka</li>
+                              <li>Datadog, AWS X-Ray, and AWS EMF</li>
+                              <li>Debug & logging</li>
                           </ul>
                       </div>
                   </div>


### PR DESCRIPTION
Mix of updates to the blog and some of the docs.

* Updates blog and index page with recent additions
* Enables showing updated time of a blog post at bottom (this is based on the last commit time)
* Link "Getting Started" to the actual getting started page, not the docs.
* Clean up the mix of ordered/unordered lists on Getting started page to improve formating.

Completes: STR-3550