### PR TITLE
Add Cloudwatch OTLP endpoints

### DIFF
--- a/docs/configuration/exporters/otlp.md
+++ b/docs/configuration/exporters/otlp.md
@@ -21,6 +21,7 @@ The OTLP exporter is the default, or can be explicitly selected with `--exporter
 | --otlp-exporter-protocol               | grpc    | grpc, http |
 | --otlp-exporter-custom-headers         |         |            |
 | --otlp-exporter-compression            | gzip    | gzip, none |
+| --otlp-exporter-authenticator          |         | sigv4auth  |
 | --otlp-exporter-tls-cert-file          |         |            |
 | --otlp-exporter-tls-cert-pem           |         |            |
 | --otlp-exporter-tls-key-file           |         |            |
@@ -36,3 +37,43 @@ The OTLP exporter is the default, or can be explicitly selected with `--exporter
 Any of the options that start with `--otlp-exporter*` can be set per telemetry type: metrics, traces or logs. For
 example, to set a custom endpoint to export traces to, set: `--otlp-exporter-traces-endpoint`. For other telemetry
 types their value falls back to the top-level OTLP exporter config.
+
+## Cloudwatch OTLP Export
+
+The Rotel OTLP exporter can export to the
+[Cloudwatch OTLP endpoints](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-OTLPEndpoint.html)
+for traces and logs. You'll need to select the HTTP protocol and enable the sigv4auth authenticator.
+
+The sigv4auth authenticator requires the AWS authentication environment variables to be set. At the moment this is restricted
+to credentials specified as: `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` and optionally `AWS_SESSION_TOKEN`.
+
+### Traces
+
+_Tracing requires that you
+enable [Transaction Search](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Transaction-Search.html)
+in the AWS console before you can send OTLP traces._
+
+Here is the full environment variable configuration to send traces to Cloudwatch, swap the region code as needed.
+
+```bash
+ROTEL_EXPORTER=otlp
+ROTEL_OTLP_EXPORTER_PROTOCOL=http
+ROTEL_OTLP_EXPORTER_TRACES_ENDPOINT=https://xray.<region code>.amazonaws.com/v1/traces
+ROTEL_OTLP_EXPORTER_AUTHENTICATOR=sigv4auth
+```
+
+### Logs
+
+_To send OTLP logs to Cloudwatch you must create a log group and log stream. Exporting will fail if these do not exist
+ahead of time and they are not created by default._
+
+Here is the full environment variable configuration to send logs to Cloudwatch, swap the region code and
+log group/stream as needed.
+
+```bash
+ROTEL_EXPORTER=otlp
+ROTEL_OTLP_EXPORTER_PROTOCOL=http
+ROTEL_OTLP_EXPORTER_TRACES_ENDPOINT=https://logs.<region code>.amazonaws.com/v1/logs
+ROTEL_OTLP_EXPORTER_LOGS_CUSTOM_HEADERS="x-aws-log-group=<log group>,x-aws-log-stream=<log stream>"
+ROTEL_OTLP_EXPORTER_AUTHENTICATOR=sigv4auth
+```

--- a/docs/configuration/exporters/otlp.md
+++ b/docs/configuration/exporters/otlp.md
@@ -49,10 +49,6 @@ to credentials specified as: `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` and op
 
 ### Traces
 
-_Tracing requires that you
-enable [Transaction Search](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Transaction-Search.html)
-in the AWS console before you can send OTLP traces._
-
 Here is the full environment variable configuration to send traces to Cloudwatch, swap the region code as needed.
 
 ```bash
@@ -62,10 +58,15 @@ ROTEL_OTLP_EXPORTER_TRACES_ENDPOINT=https://xray.<region code>.amazonaws.com/v1/
 ROTEL_OTLP_EXPORTER_AUTHENTICATOR=sigv4auth
 ```
 
-### Logs
+:::note
 
-_To send OTLP logs to Cloudwatch you must create a log group and log stream. Exporting will fail if these do not exist
-ahead of time and they are not created by default._
+Tracing requires that you
+enable [Transaction Search](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Transaction-Search.html)
+in the AWS console before you can send OTLP traces.
+
+:::
+
+### Logs
 
 Here is the full environment variable configuration to send logs to Cloudwatch, swap the region code and
 log group/stream as needed.
@@ -77,3 +78,10 @@ ROTEL_OTLP_EXPORTER_TRACES_ENDPOINT=https://logs.<region code>.amazonaws.com/v1/
 ROTEL_OTLP_EXPORTER_LOGS_CUSTOM_HEADERS="x-aws-log-group=<log group>,x-aws-log-stream=<log stream>"
 ROTEL_OTLP_EXPORTER_AUTHENTICATOR=sigv4auth
 ```
+
+:::note
+
+To send OTLP logs to Cloudwatch you must create a log group and log stream. Exporting will fail if these do not exist
+ahead of time and they are not created by default.
+
+:::

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -232,12 +232,12 @@ const config: Config = {
       theme: prismThemes.github,
       darkTheme: prismThemes.dracula,
     },
-    announcementBar: {
-      id: 'announce_blog_post',
-      content: '📢 Check out our recent <a target="_blank" rel="noopener noreferrer" href="/blog/rotel-fast-and-efficient-opentelemetry-collection-in-rust">announcement</a> about Rotel on our blog. 🎉',
-      backgroundColor: "#25c2a0",
-      isCloseable: true,
-    },
+    // announcementBar: {
+    //   id: 'announce_blog_post',
+    //   content: '📢 Check out our recent <a target="_blank" rel="noopener noreferrer" href="/blog/rotel-fast-and-efficient-opentelemetry-collection-in-rust">announcement</a> about Rotel on our blog. 🎉',
+    //   backgroundColor: "#25c2a0",
+    //   isCloseable: true,
+    // },
   } satisfies Preset.ThemeConfig,
 };
 

--- a/src/plugins/changelog/util.ts
+++ b/src/plugins/changelog/util.ts
@@ -64,7 +64,13 @@ export async function fetchGitHubReleases(
     owner: string,
     repo: string,
 ): Promise<GitHubRelease[]> {
-    const url = `https://api.github.com/repos/${owner}/${repo}/releases`;
+  // Don't fetch releases in local dev mode because we'll likely hit Github
+  // API request limits. Override by setting FORCE_FETCH_GITHUB_RELEASES envvar.
+  if (!process.env.CI && !process.env.FORCE_FETCH_GITHUB_RELEASES) {
+    return [];
+  }
+
+  const url = `https://api.github.com/repos/${owner}/${repo}/releases`;
 
     try {
 


### PR DESCRIPTION
Adds mention of the Cloudwatch OTLP endpoints to the OTLP exporter config.

Also:
* Removes announcement bar about intro post.
* Disables fetching changelog entries when in local-dev mode (hits API limits and throws errors)

Completes: STR-3568