### PR TITLE
Use bash over shell markdown blocks

### DIFF
--- a/docs/aws-lambda-extension/configuration.md
+++ b/docs/aws-lambda-extension/configuration.md
@@ -11,7 +11,7 @@ To ease configuration for Lambda environments, you can set `ROTEL_ENV_FILE` to t
 name of a file and that file will be interpreted as an `.env` file. For example, set
 `ROTEL_ENV_FILE=/var/task/rotel.env` and include the following `rotel.env` file in your
 function bundle:
-```shell
+```bash
 ROTEL_OTLP_EXPORTER_ENDPOINT=https://api.axiom.co
 ROTEL_OTLP_EXPORTER_PROTOCOL=http
 ROTEL_OTLP_EXPORTER_CUSTOM_HEADERS="Authorization=Bearer ${AXIOM_API_KEY},X-Axiom-Dataset=${AXIOM_DATASET}"

--- a/docs/aws-lambda-extension/secrets.md
+++ b/docs/aws-lambda-extension/secrets.md
@@ -10,7 +10,7 @@ files.
 
 ## AWS Secrets Manager Example
 
-```shell
+```bash
 ROTEL_OTLP_EXPORTER_ENDPOINT=https://api.axiom.co
 ROTEL_OTLP_EXPORTER_PROTOCOL=http
 ROTEL_OTLP_EXPORTER_CUSTOM_HEADERS="Authorization=Bearer ${arn:aws:secretsmanager:us-east-1:123377354456:secret:axiom-api-key-r1l7G9},X-Axiom-Dataset=${AXIOM_DATASET}"
@@ -28,7 +28,7 @@ if the secret named `axiom-r1l7G9` contained:
 ```
 
 Then the following example would extract those values:
-```shell
+```bash
 ROTEL_OTLP_EXPORTER_ENDPOINT=https://api.axiom.co
 ROTEL_OTLP_EXPORTER_PROTOCOL=http
 ROTEL_OTLP_EXPORTER_CUSTOM_HEADERS="Authorization=Bearer ${arn:aws:secretsmanager:us-east-1:123377354456:secret:axiom-r1l7G9#key},X-Axiom-Dataset=${arn:aws:secretsmanager:us-east-1:123377354456:secret:axiom-r1l7G9#dataset}"
@@ -37,7 +37,7 @@ ROTEL_OTLP_EXPORTER_CUSTOM_HEADERS="Authorization=Bearer ${arn:aws:secretsmanage
 
 ## AWS Parameter Store Example
 
-```shell
+```bash
 ROTEL_OTLP_EXPORTER_ENDPOINT=https://api.axiom.co
 ROTEL_OTLP_EXPORTER_PROTOCOL=http
 ROTEL_OTLP_EXPORTER_CUSTOM_HEADERS="Authorization=Bearer ${arn:aws:ssm:us-east-1:123377354456:parameter/axiom-api-key},X-Axiom-Dataset=${AXIOM_DATASET}"
@@ -47,12 +47,12 @@ ROTEL_OTLP_EXPORTER_CUSTOM_HEADERS="Authorization=Bearer ${arn:aws:ssm:us-east-1
 
 In addition to the `${arn:...}` format, you can also use a URI format with the prefix `secret://`. This can be easier to use in configuration
 formats that reserve the `${..}` syntax for variable interpolation. The URI format must be set at the beginning of the variable name, so:
-```shell
+```bash
 ROTEL_CLICKHOUSE_EXPORTER_PASSWORD="secret://arn:aws:ssm:us-east-1:123377354456:parameter/clickhouse-password"
 ```
 
 This supports the `#json-key` format as well to extract JSON secrets:
-```shell
+```bash
 ROTEL_CLICKHOUSE_EXPORTER_PASSWORD="secret://arn:aws:secretsmanager:us-east-1:123377354456:secret:ch-creds-r1l7G9#password"
 ```
 

--- a/docs/configuration/base.md
+++ b/docs/configuration/base.md
@@ -7,7 +7,7 @@ sidebar_position: 1
 Rotel is configured on the command line with multiple flags. See the table below for the full list of options. Rotel
 will also output the full argument list:
 
-```shell
+```bash
 rotel start --help
 ```
 

--- a/docs/configuration/exporters/kafka.md
+++ b/docs/configuration/exporters/kafka.md
@@ -61,7 +61,7 @@ durability:
 
 For secure connections, you can configure SASL authentication:
 
-```shell
+```bash
 rotel start --exporter kafka \
   --kafka-exporter-brokers "broker1:9092,broker2:9092" \
   --kafka-exporter-sasl-username "your-username" \
@@ -106,7 +106,7 @@ These options override the global partitioner setting for specific telemetry typ
 For advanced use cases, you can set arbitrary Kafka producer configuration parameters using the
 `--kafka-exporter-custom-config` option. This accepts comma-separated key=value pairs:
 
-```shell
+```bash
 rotel start --exporter kafka \
   --kafka-exporter-custom-config "enable.idempotence=true,max.in.flight.requests.per.connection=1" \
   --kafka-exporter-brokers "broker1:9092,broker2:9092"
@@ -115,7 +115,7 @@ rotel start --exporter kafka \
 **Configuration Precedence**: Custom configuration parameters are applied *after* all built-in options, meaning they
 will override any conflicting built-in settings. For example:
 
-```shell
+```bash
 # The custom config will override the built-in batch size setting
 rotel start --exporter kafka \
   --kafka-exporter-batch-size 500000 \

--- a/docs/configuration/multiple-exporters.md
+++ b/docs/configuration/multiple-exporters.md
@@ -22,7 +22,7 @@ First start by defining the set of exporters that you would like to use, optiona
 to differentiate their configuration options. For example, to export logs and metrics to two separate Clickhouse nodes
 while exporting traces to Datadog, we'll use the following `--exporters` argument (or `ROTEL_EXPORTERS` envvar):
 
-```shell
+```bash
 --exporters logging:clickhouse,stats:clickhouse,datadog
 ```
 
@@ -45,7 +45,7 @@ would need to include a username/password, but we are skipping those for brevity
 Lastly, the user would need to connect these exporters to the telemetry types. Using the requirements above, the user
 would specify the following:
 
-```shell
+```bash
 --exporters-traces datadog --exporters-metrics stats --exporters-logs logging
 ```
 


### PR DESCRIPTION
Bash seems to be more appropriate for these and may give better highlighting support. While I didn't notice anything different in the output here, they are highlighted different, and improved, in the local editor environment.
